### PR TITLE
Custom install configs

### DIFF
--- a/modules/clusterpool/Makefile
+++ b/modules/clusterpool/Makefile
@@ -138,8 +138,8 @@ clusterpool/aws/create-clusterpool: %aws/create-clusterpool: %_init
 		> .$(CLUSTERPOOL_NAME).aws.clusterpool.yaml
 	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
 		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
-			oc create secret generic install.aws.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.aws.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE); else \
-			oc create secret generic install.aws.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE); fi; \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.aws.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.aws.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.aws.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
 		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.aws.secret;g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).aws.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_AWS_CRED_NAME__;$(CLUSTERPOOL_AWS_CRED_NAME);g" \
@@ -168,8 +168,8 @@ clusterpool/azure/create-clusterpool: %azure/create-clusterpool: %_init
 		> .$(CLUSTERPOOL_NAME).az.clusterpool.yaml
 	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
 		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
-			oc create secret generic install.azure.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.azure.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE); else \
-			oc create secret generic install.azure.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE); fi; \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.azure.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.azure.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.azure.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
 		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.azure.secret;g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).az.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_AZURE_CREDS_NAME__;$(CLUSTERPOOL_AZURE_CRED_NAME);g" \
@@ -199,8 +199,8 @@ clusterpool/gcp/create-clusterpool: %gcp/create-clusterpool: %_init
 		> .$(CLUSTERPOOL_NAME).gcp.clusterpool.yaml
 	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
 		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
-			oc create secret generic install.gcp.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.gcp.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE); else \
-			oc create secret generic install.gcp.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE); fi; \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.gcp.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.gcp.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.gcp.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
 		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.gcp.secret;g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).gcp.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_GCP_CREDS_NAME__;$(CLUSTERPOOL_GCP_CRED_NAME);g" \

--- a/modules/clusterpool/Makefile
+++ b/modules/clusterpool/Makefile
@@ -30,7 +30,7 @@ CLUSTERPOOL_CHECKOUT_TIMEOUT_MINUTES ?= 10
 CLUSTERPOOL_LIFETIME ?=
 CLUSTERPOOL_GROUP_NAME ?= system:masters
 CLUSTERPOOL_SERVICE_ACCOUNT ?=
-
+CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM = `head /dev/urandom | LC_CTYPE=C tr -dc "[:lower:][:digit:]" | head -c 5 ; echo ''`
 # AWS
 CLUSTERPOOL_AWS_BASE_DOMAIN ?=
 CLUSTERPOOL_AWS_REGION ?= us-east-1
@@ -138,9 +138,9 @@ clusterpool/aws/create-clusterpool: %aws/create-clusterpool: %_init
 		> .$(CLUSTERPOOL_NAME).aws.clusterpool.yaml
 	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
 		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
-			$(SELF) oc/command OC_COMMAND="create secret generic install.aws.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.aws.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
-			$(SELF) oc/command OC_COMMAND="create secret generic install.aws.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
-		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.aws.secret;g" \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.aws.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM) --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.aws.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.aws.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM) --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
+		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.aws.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM);g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).aws.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_AWS_CRED_NAME__;$(CLUSTERPOOL_AWS_CRED_NAME);g" \
 		-e "s;__CLUSTERPOOL_AWS_REGION__;$(CLUSTERPOOL_AWS_REGION);g" \
@@ -168,9 +168,9 @@ clusterpool/azure/create-clusterpool: %azure/create-clusterpool: %_init
 		> .$(CLUSTERPOOL_NAME).az.clusterpool.yaml
 	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
 		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
-			$(SELF) oc/command OC_COMMAND="create secret generic install.azure.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.azure.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
-			$(SELF) oc/command OC_COMMAND="create secret generic install.azure.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
-		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.azure.secret;g" \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.azure.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM) --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.azure.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.azure.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM) --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
+		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.azure.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM);g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).az.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_AZURE_CREDS_NAME__;$(CLUSTERPOOL_AZURE_CRED_NAME);g" \
 		-e "s;__CLUSTERPOOL_AZURE_REGION__;$(CLUSTERPOOL_AZURE_REGION);g" \
@@ -199,9 +199,9 @@ clusterpool/gcp/create-clusterpool: %gcp/create-clusterpool: %_init
 		> .$(CLUSTERPOOL_NAME).gcp.clusterpool.yaml
 	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
 		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
-			$(SELF) oc/command OC_COMMAND="create secret generic install.gcp.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.gcp.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
-			$(SELF) oc/command OC_COMMAND="create secret generic install.gcp.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
-		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.gcp.secret;g" \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.gcp.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM) --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.gcp.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE)"; else \
+			$(SELF) oc/command OC_COMMAND="create secret generic install.gcp.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM) --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE)"; fi; \
+		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.gcp.secret.$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_RANDOM);g" \
 			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).gcp.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_GCP_CREDS_NAME__;$(CLUSTERPOOL_GCP_CRED_NAME);g" \
 		-e "s;__CLUSTERPOOL_GCP_REGION__;$(CLUSTERPOOL_GCP_REGION);g" \

--- a/modules/clusterpool/Makefile
+++ b/modules/clusterpool/Makefile
@@ -136,6 +136,12 @@ clusterpool/aws/create-clusterpool: %aws/create-clusterpool: %_init
 		-e "s;__CLUSTERPOOL_PULL_SECRET_NAME__;$(CLUSTERPOOL_PULL_SECRET_NAME);g" \
 		$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.prefix.yaml.template \
 		> .$(CLUSTERPOOL_NAME).aws.clusterpool.yaml
+	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
+		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
+			oc create secret generic install.aws.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.aws.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE); else \
+			oc create secret generic install.aws.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE); fi; \
+		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.aws.secret;g" \
+			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).aws.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_AWS_CRED_NAME__;$(CLUSTERPOOL_AWS_CRED_NAME);g" \
 		-e "s;__CLUSTERPOOL_AWS_REGION__;$(CLUSTERPOOL_AWS_REGION);g" \
 		$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.suffix.aws.yaml.template \
@@ -160,6 +166,12 @@ clusterpool/azure/create-clusterpool: %azure/create-clusterpool: %_init
 		-e "s;__CLUSTERPOOL_PULL_SECRET_NAME__;$(CLUSTERPOOL_PULL_SECRET_NAME);g" \
 		$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.prefix.yaml.template \
 		> .$(CLUSTERPOOL_NAME).az.clusterpool.yaml
+	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
+		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
+			oc create secret generic install.azure.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.azure.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE); else \
+			oc create secret generic install.azure.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE); fi; \
+		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.azure.secret;g" \
+			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).az.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_AZURE_CREDS_NAME__;$(CLUSTERPOOL_AZURE_CRED_NAME);g" \
 		-e "s;__CLUSTERPOOL_AZURE_REGION__;$(CLUSTERPOOL_AZURE_REGION);g" \
 		-e "s;__CLUSTERPOOL_AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME__;$(CLUSTERPOOL_AZURE_BASE_DOMAIN_RESOURCE_GROUP_NAME);g" \
@@ -185,6 +197,12 @@ clusterpool/gcp/create-clusterpool: %gcp/create-clusterpool: %_init
 		-e "s;__CLUSTERPOOL_PULL_SECRET_NAME__;$(CLUSTERPOOL_PULL_SECRET_NAME);g" \
 		$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.prefix.yaml.template \
 		> .$(CLUSTERPOOL_NAME).gcp.clusterpool.yaml
+	@if [ ! -z "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
+		if [ "default" ==  "$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE)" ]; then \
+			oc create secret generic install.gcp.secret --from-file=$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/install-config.gcp.yaml.template -n $(CLUSTERPOOL_HOST_NAMESPACE); else \
+			oc create secret generic install.gcp.secret --from-file=$(CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE) -n $(CLUSTERPOOL_HOST_NAMESPACE); fi; \
+		sed -e "s;__CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__;install.gcp.secret;g" \
+			$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template >> .$(CLUSTERPOOL_NAME).gcp.clusterpool.yaml; fi
 	@sed -e "s;__CLUSTERPOOL_GCP_CREDS_NAME__;$(CLUSTERPOOL_GCP_CRED_NAME);g" \
 		-e "s;__CLUSTERPOOL_GCP_REGION__;$(CLUSTERPOOL_GCP_REGION);g" \
 		$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/clusterpool/templates/clusterpool.suffix.gcp.yaml.template \

--- a/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template
+++ b/modules/clusterpool/templates/clusterpool.installconfigsecret.yaml.template
@@ -1,0 +1,2 @@
+  installConfigSecretTemplateRef:
+    name: __CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME__

--- a/modules/clusterpool/templates/install-config.aws.yaml.template
+++ b/modules/clusterpool/templates/install-config.aws.yaml.template
@@ -1,0 +1,39 @@
+apiVersion: v1
+metadata:
+  name: 
+baseDomain: 
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+  platform:
+    aws:
+      rootVolume:
+        iops: 4000
+        size: 100
+        type: io1
+      type: m5.xlarge
+compute:
+- hyperthreading: Enabled
+  name: worker
+  replicas: 3
+  platform:
+    aws:
+      rootVolume:
+        iops: 2000
+        size: 100
+        type: io1
+      type: m5.xlarge
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  aws:
+    region: us-east-1
+pullSecret: "" # skip, hive will inject based on it's secrets
+

--- a/modules/clusterpool/templates/install-config.azure.yaml.template
+++ b/modules/clusterpool/templates/install-config.azure.yaml.template
@@ -1,0 +1,40 @@
+apiVersion: v1
+metadata:
+  name: 
+baseDomain: 
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 128
+      type:  Standard_D4s_v3
+compute:
+- hyperthreading: Enabled
+  name: worker
+  replicas: 3
+  platform:
+    azure:
+      type:  Standard_D2s_v3
+      osDisk:
+        diskSizeGB: 128
+      zones:
+      - "1"
+      - "2"
+      - "3"
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  azure:
+    baseDomainResourceGroupName: 
+    region: centralus
+pullSecret: "" # skip, hive will inject based on it's secrets
+

--- a/modules/clusterpool/templates/install-config.gcp.yaml.template
+++ b/modules/clusterpool/templates/install-config.gcp.yaml.template
@@ -1,0 +1,32 @@
+apiVersion: v1
+metadata:
+  name: 
+baseDomain: 
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+  platform:
+    gcp:
+      type: n1-standard-4
+compute:
+- hyperthreading: Enabled
+  name: worker
+  replicas: 3
+  platform:
+    gcp:
+      type: n1-standard-4
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  gcp:
+    projectID:
+    region: us-east1
+pullSecret: "" # skip, hive will inject based on it's secrets
+


### PR DESCRIPTION
Here's the behavior as it stands now - see if this is getting close:
During `make clusterpool/<cloud provider>/create-clusterpool`, If there is an environment variable `CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE`, based on its contents, one of two things will happen:
1. If `CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE=default`:
 - The templated custom install config file for the appropriate `<cloud provider>` will be used to create a secret named `install.<cloud provider>.secret` and a `installConfigSecretTemplateRef` clause will be added to the clusterpool creation yaml
2. If `CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE=<specification>`:
 - The file named `<specification>` will be used to create a secret named `install.<cloud provider>.secret` and a `installConfigSecretTemplateRef` clause will be added to the clusterpool creation yaml

If there is no `CLUSTERPOOL_INSTALL_CONFIG_SECRET_FILE` variable present (or if it is empty), the `installConfigSecretTemplateRef` clause will be omitted from the clusterpool creation yaml.