### PR TITLE
ocsi_publish.sh: Abort on failing git clone for pipeline repo

### DIFF
--- a/modules/osci/bin/osci_publish.sh
+++ b/modules/osci/bin/osci_publish.sh
@@ -19,8 +19,11 @@ while true; do
 		rm -rf $OSCI_PIPELINE_DIR
 	fi
 	echo ">>> Incoming: OSCI_PIPELINE_PRODUCT_PREFIX=$OSCI_PIPELINE_PRODUCT_PREFIX, OSCI_RELEASE_VERSION=$OSCI_RELEASE_VERSION"
-	echo ">>> Cloning the pipeline repo from $OSCI_PIPELINE_GIT_URL, branch $OSCI_PIPELINE_GIT_BRANCH"
-	git clone -b $OSCI_PIPELINE_GIT_BRANCH $OSCI_PIPELINE_GIT_URL $OSCI_PIPELINE_DIR
+	echo ">>> Cloning the pipeline repo from $OSCI_PIPELINE_SITE/$OSCI_PIPELINE_ORG/$OSCI_PIPELINE_REPO.git, branch $OSCI_PIPELINE_GIT_BRANCH"
+	git clone -b $OSCI_PIPELINE_GIT_BRANCH $OSCI_PIPELINE_GIT_URL $OSCI_MANIFEST_DIR || {
+		echo "Could not clone pipeline repo. Aborting"
+		exit 1
+	}
 	echo ">>> Setting git user name and email"
 	pushd $OSCI_PIPELINE_DIR > /dev/null
 	git config user.email $OSCI_GIT_USER_EMAIL


### PR DESCRIPTION
This changes the echo for the git clone to not include secrets and aborts if this clone of the pipeline repo fails.

Context on this the secret passing is failing in the prow step registry for the step I made. I have some concerns about the secrets leaking with the existing echo. Related PR: https://github.com/openshift/release/pull/25671