### PR TITLE
Fetch and rebase branch for SonarCloud

### DIFF
--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -34,6 +34,20 @@ sonar/go/prow:
 	gosec -fmt sonarqube -out gosec.json -no-fail ./... 
 	@cp gosec.json "${ARTIFACT_DIR}/sonar_gosec.json"
 	
+	@if [[ "${REPO_OWNER}" != "openshift" ]] && [[ "${REPO_NAME}" != "release" ]]; then \
+		echo "Fetch ${REPO_OWNER}/${REPO_NAME} and rebase the commits onto ${PULL_BASE_REF}" | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		git remote add origin https://github.com/${REPO_OWNER}/${REPO_NAME} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		git fetch origin | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		git rebase origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		if [[ "${JOB_TYPE}" == "presubmit" ]]; then \
+			BRANCH=$(shell curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref"); \
+			echo "Creating and checking out to branch $${BRANCH}" | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+			git branch $${BRANCH} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+			git reset --hard origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+			git checkout $${BRANCH} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		fi; \
+	fi
+
 	@echo "Starting Sonar Scanner" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@echo "SONAR_ORG=${SONAR_ORG}" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@echo "JOB_TYPE=${JOB_TYPE}" | tee -a "${ARTIFACT_DIR}/sonar.log"
@@ -150,7 +164,21 @@ sonar/js/prow: export SONAR_TOKEN="$(shell cat /etc/sonarcloud/token 2> /dev/nul
 sonar/js/prow:
 	@echo "Verify sonar token from kube secret has been mounted" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@if [[ -z "${SONAR_TOKEN}" ]] ; then echo "---> ERROR: SONAR_TOKEN is not set" | tee -a "${ARTIFACT_DIR}/sonar.log" ; exit 1 ; fi
-	
+
+	@if [[ "${REPO_OWNER}" != "openshift" ]] && [[ "${REPO_NAME}" != "release" ]]; then \
+		echo "Fetch ${REPO_OWNER}/${REPO_NAME} and rebase the commits onto ${PULL_BASE_REF}" | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		git remote add origin https://github.com/${REPO_OWNER}/${REPO_NAME} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		git fetch origin | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		git rebase origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		if [[ "${JOB_TYPE}" == "presubmit" ]]; then \
+			BRANCH=$(shell curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref"); \
+			echo "Creating and checking out to branch $${BRANCH}" | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+			git branch $${BRANCH} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+			git reset --hard origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+			git checkout $${BRANCH} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
+		fi; \
+	fi
+
 	@echo "Starting Sonar Scanner" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@echo "SONAR_ORG=${SONAR_ORG}" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@echo "JOB_TYPE=${JOB_TYPE}" | tee -a "${ARTIFACT_DIR}/sonar.log"


### PR DESCRIPTION
The background is that I discovered Prow fetches commits manually but doesn't appear to collect references SonarCloud needs, for example here were the image build commands from my test repo for a PR:
```shell
mkdir -p /go/src/github.com/${REPO_OWNER}/${REPO_NAME}
git init
git config user.name ci-robot
git config user.email ci-robot@openshift.io
git fetch https://github.com/${REPO_OWNER}/${REPO_NAME}.git --tags --prune
git fetch https://github.com/${REPO_OWNER}/${REPO_NAME}.git ${BASE_BRANCH_HASH}
git checkout ${BASE_BRANCH_HASH}
git branch --force ${PULL_BASE_REF} ${BASE_BRANCH_HASH}
git checkout ${PULL_BASE_REF}
git fetch https://github.com/${REPO_OWNER}/${REPO_NAME}.git ${PR_BRANCH_HASH}
GIT_AUTHOR_DATE=1644630248 GIT_COMMITTER_DATE=1644630248 git merge --no-ff ${PR_BRANCH_HASH}
git submodule update --init --recursive
```

This also results in a merge commit that SonarCloud can't reconcile with anything on any branch because it doesn't exist anywhere in GitHub. Fetching the references, rebasing, and switching to a branch of the same name seems to help SonarCloud reconcile the commits:
```shell
git remote add origin https://github.com/${REPO_OWNER}/${REPO_NAME}
git fetch origin
git rebase origin/${PULL_BASE_REF}
BRANCH=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref")
git branch ${BRANCH}
git reset --hard origin/${PULL_BASE_REF}
git checkout ${BRANCH}
```

I implemented it as a big ugly one-liner so that it wouldn't fail when trying to fetch and rebase with the `openshift/release` repo. I couldn't test a postsubmit, but theoretically it should work since the commands are the same in the build (except it doesn't fetch and merge the commit reference from the PR).