### PR TITLE
Add check for quality gate to SonarCloud

### DIFF
--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -56,6 +56,8 @@ sonar/go/prow:
 	@sonar-scanner -Dsonar.login=${SONAR_TOKEN} \
 		-Dsonar.organization="${SONAR_ORG}" \
 		-Dsonar.host.url=https://sonarcloud.io \
+		-Dsonar.qualitygate.wait=true \
+		-Dsonar.qualitygate.timeout=450 \
 		--debug > >(tee -a "${ARTIFACT_DIR}/sonar.log")
 
 
@@ -173,4 +175,6 @@ sonar/js/prow:
 	@sonar-scanner -Dsonar.login=${SONAR_TOKEN} \
 		-Dsonar.organization="${SONAR_ORG}" \
 		-Dsonar.host.url=https://sonarcloud.io \
+		-Dsonar.qualitygate.wait=true \
+		-Dsonar.qualitygate.timeout=450 \
 		--debug > >(tee -a "${ARTIFACT_DIR}/sonar.log")


### PR DESCRIPTION
Adds a Quality Gate check so that if the Quality Gate fails, the job will also fail.

Followup to:
- #168 