### PR TITLE
Use target branch instead of `main`

### DIFF
--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -52,8 +52,9 @@ sonar/go/prow:
 	@echo "JOB_TYPE=${JOB_TYPE}" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@echo "PULL_BASE_REF=${PULL_BASE_REF}" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@if [[ "${REPO_OWNER}" == "openshift" ]] && [[ "${REPO_NAME}" == "release" ]]; then \
-		echo "Detected openshift/release repo. Running a postsubmit scan on 'main' branch."; \
-		echo "sonar.branch.name=main" >> sonar-project.properties ; \
+		TARGET_BRANCH="$(echo "${JOB_SPEC}" | jq -r '.extra_refs[] | select(.workdir == true).base_ref')"; \
+		echo "Detected openshift/release repo. Running a postsubmit scan on '${TARGET_BRANCH}' branch."; \
+		echo "sonar.branch.name=${TARGET_BRANCH}" >> sonar-project.properties ; \
 	elif [[ "${JOB_TYPE}" == "presubmit" ]]; then \
 		echo "PULL_NUMBER=${PULL_NUMBER}" | tee -a "${ARTIFACT_DIR}/sonar.log" ; \
 		echo "REPO_OWNER=${REPO_OWNER}" | tee -a "${ARTIFACT_DIR}/sonar.log" ; \
@@ -188,8 +189,9 @@ sonar/js/prow:
 	@echo "JOB_TYPE=${JOB_TYPE}" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@echo "PULL_BASE_REF=${PULL_BASE_REF}" | tee -a "${ARTIFACT_DIR}/sonar.log"
 	@if [[ "${REPO_OWNER}" == "openshift" ]] && [[ "${REPO_NAME}" == "release" ]]; then \
-		echo "Detected openshift/release repo. Running a postsubmit scan on 'main' branch."; \
-		echo "sonar.branch.name=main" >> sonar-project.properties ; \
+		TARGET_BRANCH="$(echo "${JOB_SPEC}" | jq -r '.extra_refs[] | select(.workdir == true).base_ref')"; \
+		echo "Detected openshift/release repo. Running a postsubmit scan on '${TARGET_BRANCH}' branch."; \
+		echo "sonar.branch.name=${TARGET_BRANCH}" >> sonar-project.properties ; \
 	elif [[ "${JOB_TYPE}" == "presubmit" ]]; then \
 		echo "PULL_NUMBER=${PULL_NUMBER}" | tee -a "${ARTIFACT_DIR}/sonar.log" ; \
 		echo "REPO_OWNER=${REPO_OWNER}" | tee -a "${ARTIFACT_DIR}/sonar.log" ; \


### PR DESCRIPTION
I realized by defaulting to `main`, it may be oversimplifying and do strange things to Sonar scans when a `release-*` branch is actually being scanned. This instead digs through the Prow job spec to grab the target branch.

References:
- Pod/cloning configuration: https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md#how-to-configure
- Prow variables: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables

Followup to:
- #173 