### PR TITLE
Prevent branch name conflicts in SonarCloud

### DIFF
--- a/modules/sonar/Makefile
+++ b/modules/sonar/Makefile
@@ -39,7 +39,7 @@ sonar/go/prow:
 		git fetch origin | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 		git rebase --strategy-option=theirs origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 		if [[ "${JOB_TYPE}" == "presubmit" ]]; then \
-			BRANCH=$(shell curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref"); \
+			BRANCH="$(shell curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref")-pr${PULL_BASE_REF}"; \
 			echo "Creating and checking out to branch $${BRANCH}" | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 			git branch $${BRANCH} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 			git reset --hard origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
@@ -176,7 +176,7 @@ sonar/js/prow:
 		git fetch origin | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 		git rebase --strategy-option=theirs origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 		if [[ "${JOB_TYPE}" == "presubmit" ]]; then \
-			BRANCH=$(shell curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref"); \
+			BRANCH="$(shell curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq ".head.ref")-pr${PULL_BASE_REF}"; \
 			echo "Creating and checking out to branch $${BRANCH}" | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 			git branch $${BRANCH} | tee -a "${ARTIFACT_DIR}/sonar.log"; \
 			git reset --hard origin/${PULL_BASE_REF} | tee -a "${ARTIFACT_DIR}/sonar.log"; \


### PR DESCRIPTION
When the forked branch has exactly the same name, the rebase fails and then runs a scan with zero changes:
```
fatal: A branch named 'release-2.4' already exists.
```

This should fix this collision. Since we set the `sonar.pullrequest.branch` manually for SonarCloud, I don't think the name difference should affect the scan result, but I'll test that out.

Identified in PR:
- https://github.com/stolostron/grc-ui/pull/901
- [Sonar logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stolostron_grc-ui/901/pull-ci-stolostron-grc-ui-release-2.4-lint-unittest-sonarcloud/1545426724504735744/artifacts/test/build-log.txt)