### PR TITLE
Patch a version mismatch between the osci/publish tag and ocm-ci-image-mirror destination tag

### DIFF
--- a/modules/osci/Makefile
+++ b/modules/osci/Makefile
@@ -9,10 +9,6 @@ export OSCI_COMPONENT_BRANCH ?= ${PULL_BASE_REF}
 export OSCI_COMPONENT_SHA256 ?= ${PULL_BASE_SHA}
 
 export OSCI_COMPONENT_NAME ?= $(shell cat COMPONENT_NAME 2> /dev/null)
-export OSCI_COMPONENT_VERSION ?= $(shell cat COMPONENT_VERSION 2> /dev/null)
-
-export OSCI_COMPONENT_SUFFIX ?= $(OSCI_COMPONENT_SHA256)
-export OSCI_COMPONENT_TAG ?= $(OSCI_COMPONENT_VERSION)-$(OSCI_COMPONENT_SUFFIX)
 
 export OSCI_PIPELINE_PRODUCT_PREFIX ?= release
 
@@ -48,16 +44,19 @@ export OSCI_GIT_USER_NAME ?= "ACM CICD"
 export OSCI_GIT_USER_EMAIL ?= "acm-cicd@redhat.com"
 export OSCI_GIT_MESSAGE ?= Added or Updated $(OSCI_COMPONENT_NAME)
 
+export OSCI_Z_RELEASE_VERSION ?= $(shell curl --silent -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/${OSCI_PIPELINE_ORG}/release/${OSCI_COMPONENT_BRANCH}/Z_RELEASE_VERSION)\
+
+export OSCI_COMPONENT_SUFFIX ?= $(OSCI_COMPONENT_SHA256)
+export OSCI_COMPONENT_TAG ?= $(OSCI_Z_RELEASE_VERSION)-$(OSCI_COMPONENT_SUFFIX)
+
 export OSCI_MANIFEST_QUERY ?= .[] |select(.["image-name"] == "$(OSCI_COMPONENT_NAME)")
-export OSCI_ADDITION_QUERY ?= .[. | length] |= . + {"image-name": "$(OSCI_COMPONENT_NAME)", "image-version": "$(OSCI_COMPONENT_VERSION)", "image-tag": "$(OSCI_COMPONENT_TAG)", "git-sha256": "$(OSCI_COMPONENT_SHA256)", "git-repository": "$(OSCI_COMPONENT_REPO)",  "image-remote": "$(OSCI_IMAGE_REMOTE_REPO_DST)", "image-remote-src": "$(OSCI_IMAGE_REMOTE_REPO_SRC)"}
+export OSCI_ADDITION_QUERY ?= .[. | length] |= . + {"image-name": "$(OSCI_COMPONENT_NAME)", "image-version": "$(OSCI_RELEASE_VERSION)", "image-tag": "$(OSCI_COMPONENT_TAG)", "git-sha256": "$(OSCI_COMPONENT_SHA256)", "git-repository": "$(OSCI_COMPONENT_REPO)",  "image-remote": "$(OSCI_IMAGE_REMOTE_REPO_DST)", "image-remote-src": "$(OSCI_IMAGE_REMOTE_REPO_SRC)"}
 export OSCI_DELETION_QUERY ?= .[] | select(.["image-name"] != "$(OSCI_COMPONENT_NAME)")
 export OSCI_SORT_QUERY ?= . | sort_by(.["image-name"])
 
 export OSCI_DATETIME := $(shell (date +%Y-%m-%d-%H-%M-%S))
 
-export OSCI_Z_RELEASE_VERSION ?= $(shell curl --silent -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/${OSCI_PIPELINE_ORG}/release/${OSCI_COMPONENT_BRANCH}/Z_RELEASE_VERSION)
-
 .PHONY: osci/publish
-## Add or update component $OSCI_COMPONENT_NAME to have version $OSCI_COMPONENT_VERSION in the pipeline manifest in stage $OSCI_PIPELINE_STAGE
+## Add or update component $OSCI_COMPONENT_NAME to have version $OSCI_Z_RELEASE_VERSION in the pipeline manifest in stage $OSCI_PIPELINE_STAGE
 osci/publish:
 	@$(BUILD_HARNESS_EXTENSIONS_PATH)/modules/osci/bin/osci_publish.sh

--- a/modules/osci/bin/osci_publish.sh
+++ b/modules/osci/bin/osci_publish.sh
@@ -105,7 +105,7 @@ while true; do
     git commit -am "Stage $OSCI_Z_RELEASE_VERSION snapshot of $OSCI_COMPONENT_NAME-$OSCI_COMPONENT_SUFFIX"
     echo ">>> Push retag branch update to pipeline repo"
 	if git push ; then
-        echo "Successfully updated $OSCI_COMPONENT_NAME to $OSCI_COMPONENT_NAME:$OSCI_COMPONENT_VERSION in https://$OSCI_PIPELINE_SITE/$OSCI_PIPELINE_ORG/$OSCI_PIPELINE_REPO#$OSCI_RELEASE_VERSION-$OSCI_PIPELINE_STAGE"
+        echo "Successfully updated $OSCI_COMPONENT_NAME to $OSCI_COMPONENT_NAME:$OSCI_Z_RELEASE_VERSION in https://$OSCI_PIPELINE_SITE/$OSCI_PIPELINE_ORG/$OSCI_PIPELINE_REPO#$OSCI_RELEASE_VERSION-$OSCI_PIPELINE_STAGE"
 		popd > /dev/null
 		break
 	fi


### PR DESCRIPTION
## Summary of Changes

Find more details on this issue [here](https://github.com/stolostron/backlog/issues/24890) and [here](https://github.com/stolostron/backlog/issues/24967) but...

In summary - the issue involves a difference in the generation of quay.io destination image tags between the `ocm-ci-image-mirror` OSCI/Prow workflow and the tag pushed to the [pipeline](https://github.com/stolostron/pipeline/tree/2.6-integration) manifest.  

The `ocm-ci-image-mirror` workflow mirrors the built image from the CI registry by sha to quay.io and versions it as `<Z_RELEASE_VERSION-from-release-repo>-<git-sha>`.  The `osci/publish` target in the [BHE](https://github.com/stolostron/build-harness-extensions) versions the destination tag (the tag used in quay.io/stolostron) using the COMPONENT_VERSION from the repo of the component being mirrored.  If these versions in two different files/repos don't match, there will be an image mismatch and the snapshot will fail.  

To resolve this, we want to update the `osci/publish` stage to use the `Z_RELEASE_VERSION` from the [stolostron/release](https://github.com/stolostron/release/tree/release-2.6) repo.  
