### PR TITLE
Use image tag as mirror dest

### DIFF
--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -49,8 +49,9 @@ PIPELINE_STAGE ?= integration
 
 PM_MANIFEST_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)")
 PM_IMAGE_REMOTE_SRC_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)") | .["image-remote-src"]
-PM_IMAGE_VERSION_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)") | .["image-version"]
-PM_GIT_SHA_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)") | .["git-sha256"]
+# Deprecated: PM_IMAGE_VERSION_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)") | .["image-version"]
+# Deprecated PM_GIT_SHA_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)") | .["git-sha256"]
+PM_IMAGE_TAG_QUERY ?= .[] |select(.["image-name"] == "$(PIPELINE_MANIFEST_COMPONENT)") | .["image-tag"]
 PM_ADDITION_QUERY ?= .[. | length] |= . + {"image-name": "$(PIPELINE_MANIFEST_COMPONENT)", "image-version": "$(PIPELINE_MANIFEST_COMPONENT_VERSION)", "image-tag": "$(PIPELINE_MANIFEST_COMPONENT_TAG)", "git-sha256": "$(PIPELINE_MANIFEST_COMPONENT_SHA256)", "git-repository": "$(PIPELINE_MANIFEST_COMPONENT_REPO)",  "image-remote": "$(PIPELINE_MANIFEST_REMOTE_REPO)"}
 PM_DELETION_QUERY ?= .[] | select(.["image-name"] != "$(DELETED_COMPONENT)")
 PM_SORT_QUERY ?= . | sort_by(.["image-name"])
@@ -208,15 +209,13 @@ pipeline-manifest/_osci_to_quay: %_osci_to_quay: %_clone
  		echo .... image does not need to be copied from OpenShift CI ; \
  	else \
  		echo .... image needs to be copied from OpenShift CI ; \
-		$(JQ) -r '$(PM_IMAGE_VERSION_QUERY)' $(PIPELINE_MANIFEST_FILE_NAME).json > IMAGE_VERSION ; \
-		echo .... image-version is `cat IMAGE_VERSION` ; \
-		$(JQ) -r '$(PM_GIT_SHA_QUERY)' $(PIPELINE_MANIFEST_FILE_NAME).json > GIT_SHA ; \
-		echo .... git-sha is `cat GIT_SHA` ; \
+		$(JQ) -r '$(PM_IMAGE_TAG_QUERY)' $(PIPELINE_MANIFEST_FILE_NAME).json > IMAGE_TAG ; \
+		echo .... image-tag is `cat IMAGE_TAG` ; \
 		echo .. Copying from OpenShift CI to Quay ; \
 		OSCI_REMOTE="`cat IMAGE_REMOTE_SRC`/$(PIPELINE_MANIFEST_RELEASE_VERSION):$(PIPELINE_MANIFEST_COMPONENT)" ; \
 		echo .... Pulling $$OSCI_REMOTE ; \
  		$(DOCKER) pull $$OSCI_REMOTE ; \
-		QUAY_REMOTE="$(PIPELINE_MANIFEST_REMOTE_REPO)/$(PIPELINE_MANIFEST_COMPONENT):`cat IMAGE_VERSION`-`cat GIT_SHA`" ; \
+		QUAY_REMOTE="$(PIPELINE_MANIFEST_REMOTE_REPO)/$(PIPELINE_MANIFEST_COMPONENT):`cat IMAGE_TAG`"; \
 		SLACK_MESSAGE_PREP="\`${PIPELINE_MANIFEST_REPO}\` quay_retag (_osci_to_quay): :red_circle: Failure in <$$TRAVIS_BUILD_WEB_URL|retag> commit: \`$$TRAVIS_COMMIT_MESSAGE\`: osci push image $$OSCI_REMOTE to quay $$QUAY_REMOTE failed" ; \
  		echo .... Retagging to $$QUAY_REMOTE ; \
  		$(DOCKER) tag "$$OSCI_REMOTE" "$$QUAY_REMOTE" ; \

--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -215,7 +215,7 @@ pipeline-manifest/_osci_to_quay: %_osci_to_quay: %_clone
 		OSCI_REMOTE="`cat IMAGE_REMOTE_SRC`/$(PIPELINE_MANIFEST_RELEASE_VERSION):$(PIPELINE_MANIFEST_COMPONENT)" ; \
 		echo .... Pulling $$OSCI_REMOTE ; \
  		$(DOCKER) pull $$OSCI_REMOTE ; \
-		QUAY_REMOTE="$(PIPELINE_MANIFEST_REMOTE_REPO)/$(PIPELINE_MANIFEST_COMPONENT):`cat IMAGE_TAG`"; \
+		QUAY_REMOTE="$(PIPELINE_MANIFEST_REMOTE_REPO)/$(PIPELINE_MANIFEST_COMPONENT):`cat IMAGE_TAG`" ; \
 		SLACK_MESSAGE_PREP="\`${PIPELINE_MANIFEST_REPO}\` quay_retag (_osci_to_quay): :red_circle: Failure in <$$TRAVIS_BUILD_WEB_URL|retag> commit: \`$$TRAVIS_COMMIT_MESSAGE\`: osci push image $$OSCI_REMOTE to quay $$QUAY_REMOTE failed" ; \
  		echo .... Retagging to $$QUAY_REMOTE ; \
  		$(DOCKER) tag "$$OSCI_REMOTE" "$$QUAY_REMOTE" ; \


### PR DESCRIPTION
## Summary of Changes

Turns out, when components publish to the pipeline, they correctly version the image-tag by the new Z_RELEASE_VERSION-GIT_SHA tag, but the _osci_to_quay doesn't mirror the image to this tag (I just now discovered this), instead, it queries the image-version entry in the manifest and uses that version for both the floating tag pull from the CI registry and the tag construction, so we end up with the X.Y release version tag mirrored but a reference to the X.Y.Z. 

Good news is - the fix is simple.  We'll ask the mirror to use the full destination tag from image-tag in the manifest and we're good to go.