### PR TITLE
Add -L to oc curl to resolve redirect issues when accessing cross-cloud

### DIFF
--- a/modules/oc/Makefile
+++ b/modules/oc/Makefile
@@ -22,11 +22,11 @@ OC_SILENT ?= true
 oc/install: %install:
 	@if [ ! -x $(OC) ]; then \
 		if [ ! -z "$(OC_SILENT)" ]; then \
-			curl -s -X GET ${OC_SOURCE_URL} -o ${OC_TAR_PATH} > /dev/null; \
+			curl -s -L -X GET ${OC_SOURCE_URL} -o ${OC_TAR_PATH} > /dev/null; \
 			tar -xf ${OC_TAR_PATH} -C ${OC_DEST_PATH} > /dev/null; \
 			rm -f ${OC_TAR_PATH} > /dev/null; \
 		else \
-			curl -X GET ${OC_SOURCE_URL} -o ${OC_TAR_PATH}; \
+			curl -L -X GET ${OC_SOURCE_URL} -o ${OC_TAR_PATH}; \
 			tar -xf ${OC_TAR_PATH} -C ${OC_DEST_PATH}; \
 			rm -f ${OC_TAR_PATH}; \
 		fi \


### PR DESCRIPTION
## Summary of Changes

This PR _should_ resolve the issue outlined in [this thread](https://coreos.slack.com/archives/CSZLMKPS5/p1660743123341969) where OSCI produces this error when CURL-ing oc:
```
make[1]: Entering directory '/tmp/ocm-S9lcW'
make[2]: Entering directory '/tmp/ocm-S9lcW'
tar: This does not look like a tar archive
gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
/bin/bash: line 3: /opt/build-harness/build-harness/vendor/oc: No such file or directory
make[2]: *** [/opt/build-harness/build-harness/../build-harness-extensions/modules/oc/Makefile:38: oc/login] Error 127
make[2]: Leaving directory '/tmp/ocm-S9lcW'
make[1]: *** [/opt/build-harness/build-harness/../build-harness-extensions/modules/clusterpool/Makefile:90: clusterpool/_init] Error 2
make[1]: Leaving directory '/tmp/ocm-S9lcW'
```
