### PR TITLE
Updates mapping report with currently used sha of postgresql13

### DIFF
--- a/modules/pipeline-manifest/bin/_mirror-index.sh
+++ b/modules/pipeline-manifest/bin/_mirror-index.sh
@@ -14,7 +14,7 @@ set -e
 
 # We send out the postgres sha to the downstream mapping file... this is the hardcoded version we are using today:
 postgres_spec_12=registry.redhat.io/rhel8/postgresql-12@sha256:da0b8d525b173ef472ff4c71fae60b396f518860d6313c4f3287b844aab6d622
-postgres_spec_13=registry.redhat.io/rhel8/postgresql-13@sha256:4bb562f98edc2d94299f25080dc3dd8290e5f8db2710fe8f76a5cd71442bb4c7
+postgres_spec_13=registry.redhat.io/rhel8/postgresql-13@sha256:ab0b39b37669459bee71844cc667a647451332349ea8c25428625bc6bad4b221
 
 # Take an arbitrary bundle and create an index image out of it
 # make_index Parameters:


### PR DESCRIPTION
As the tag line states, this updates the manual mapping of the currently used sha of postgresql13 for mirrorbot. This is for maintaining the correct reporting :)