### PR TITLE
Dist-git's name has changed to https://pkgs.devel.redhat.com/cgit/

### DIFF
--- a/modules/pipeline-manifest/bin/_generate_downstream_manifest.py
+++ b/modules/pipeline-manifest/bin/_generate_downstream_manifest.py
@@ -21,7 +21,7 @@ release_manifest = []
 
 def get_upstream_sha(container, sha):
     # print('looking for container {} with sha {}'.format(container,sha))
-    req_string = 'http://dist-git.host.prod.eng.bos.redhat.com/cgit/containers/{}/plain/container.yaml?id={}'.format(container,sha)
+    req_string = 'https://pkgs.devel.redhat.com/cgit/containers/{}/plain/container.yaml?id={}'.format(container,sha)
     # print (req_string)
     res = requests.get(
         req_string


### PR DESCRIPTION
## Summary of Changes

Dist-git's old DNS name has been unceremoniously and without much notification been changed, so we need to update that URL. 

[Here's](https://chat.google.com/room/AAAA-umhJ10/C_iq6TADAR8) where we found out. 