### PR TITLE
Migrate bundle listing logic to podman search to fix Pagination issues

### DIFF
--- a/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
+++ b/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
@@ -33,11 +33,12 @@ make_index () {
 	echo Locating upgrade bundles for $BUNDLE...
 
 	# Extract version list, Pull out timestamp
-	curl_output=$(curl --silent --location -H "Authorization: Bearer $REDHAT_REGISTRY_TOKEN" https://registry.redhat.io/v2/$NAMESPACE/$BUNDLE/tags/list)
+	curl_output=$(podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io & \
+    podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[]' | sort --version-sort)
 	err_code=$(echo $curl_output | jq -r '.errors[].code' 2> /dev/null )
 	echo err_code from bundle curl \(blank or 404 is good\): $err_code
 	if [[ $err_code = "404" ]] || [[ $err_code = "" ]]; then
-		echo $curl_output | jq -r '.tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
+		echo $curl_output | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
 
 		# Sort results
 		jq '. | sort_by(.["timestamp"])' $TEMPFILE > $TEMPFILE2; mv $TEMPFILE2 $TEMPFILE

--- a/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
+++ b/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
@@ -33,8 +33,8 @@ make_index () {
 	echo Locating upgrade bundles for $BUNDLE...
 
 	# Extract version list, Pull out timestamp
-	curl_output=$(podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io & \
-    podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[]' | sort --version-sort)
+  podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io
+	curl_output=$(podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[]' | sort --version-sort)
 	err_code=$(echo $curl_output | jq -r '.errors[].code' 2> /dev/null )
 	echo err_code from bundle curl \(blank or 404 is good\): $err_code
 	if [[ $err_code = "404" ]] || [[ $err_code = "" ]]; then

--- a/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
+++ b/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
@@ -34,11 +34,11 @@ make_index () {
 
 	# Extract version list, Pull out timestamp
   podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io
-	curl_output=$(podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[]' | sort --version-sort)
+	curl_output=$(podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999)
 	err_code=$(echo $curl_output | jq -r '.errors[].code' 2> /dev/null )
 	echo err_code from bundle curl \(blank or 404 is good\): $err_code
 	if [[ $err_code = "404" ]] || [[ $err_code = "" ]]; then
-		echo $curl_output | jq -r '.tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
+		echo $curl_output | jq -r '.[0].Tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | sort --version-sort | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
 
 		# Sort results
 		jq '. | sort_by(.["timestamp"])' $TEMPFILE > $TEMPFILE2; mv $TEMPFILE2 $TEMPFILE

--- a/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
+++ b/modules/pipeline-manifest/bin/_backplane_mirror_index.sh
@@ -38,7 +38,7 @@ make_index () {
 	err_code=$(echo $curl_output | jq -r '.errors[].code' 2> /dev/null )
 	echo err_code from bundle curl \(blank or 404 is good\): $err_code
 	if [[ $err_code = "404" ]] || [[ $err_code = "" ]]; then
-		echo $curl_output | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
+		echo $curl_output | jq -r '.tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
 
 		# Sort results
 		jq '. | sort_by(.["timestamp"])' $TEMPFILE > $TEMPFILE2; mv $TEMPFILE2 $TEMPFILE

--- a/modules/pipeline-manifest/bin/_mirror-index.sh
+++ b/modules/pipeline-manifest/bin/_mirror-index.sh
@@ -36,7 +36,7 @@ make_index () {
 
 	# Extract version list, Pull out timestamp
   podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io
-	podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[]' | sort --version-sort | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
+	podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | sort --version-sort | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
 	# Sort results
 	jq '. | sort_by(.["timestamp"])' $TEMPFILE > $TEMPFILE2; mv $TEMPFILE2 $TEMPFILE
 	# Filter out vX.Y results; require vX.Y.Z

--- a/modules/pipeline-manifest/bin/_mirror-index.sh
+++ b/modules/pipeline-manifest/bin/_mirror-index.sh
@@ -36,7 +36,7 @@ make_index () {
 
 	# Extract version list, Pull out timestamp
   podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io
-	podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | sort --version-sort | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
+	podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | sort --version-sort | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
 	# Sort results
 	jq '. | sort_by(.["timestamp"])' $TEMPFILE > $TEMPFILE2; mv $TEMPFILE2 $TEMPFILE
 	# Filter out vX.Y results; require vX.Y.Z

--- a/modules/pipeline-manifest/bin/_mirror-index.sh
+++ b/modules/pipeline-manifest/bin/_mirror-index.sh
@@ -35,7 +35,8 @@ make_index () {
  	echo Locating upgrade bundles for $BUNDLE...
 
 	# Extract version list, Pull out timestamp
-	curl --silent --location -H "Authorization: Bearer $REDHAT_REGISTRY_TOKEN" https://registry.redhat.io/v2/$NAMESPACE/$BUNDLE/tags/list | jq -r '.tags[] | select(test("'$PIPELINE_MANIFEST_BUNDLE_REGEX'"))' | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
+  podman login --username=$PIPELINE_MANIFEST_REDHAT_USER --password=$PIPELINE_MANIFEST_REDHAT_TOKEN registry.redhat.io
+	podman search registry.redhat.io/$NAMESPACE/$BUNDLE --list-tags --format json --limit=99999 | jq -r '.[0].Tags[]' | sort --version-sort | xargs -L1 -I'{}' $BIN_PATH/_get_timestamp.sh $TEMPFILE $BUNDLE {} $NAMESPACE
 	# Sort results
 	jq '. | sort_by(.["timestamp"])' $TEMPFILE > $TEMPFILE2; mv $TEMPFILE2 $TEMPFILE
 	# Filter out vX.Y results; require vX.Y.Z


### PR DESCRIPTION
## Summary of Changes

This changes migrates from using the Docker V2 API directly via `curl` to using `podman search` to list and filter tags on a given bundle image to be included in our custom catalog image.  This change was necessitated by a change in the V2 API implementation running underneath registry.redhat.io which began paginating results, omitting some critical values.  `podman search`  allows you to configure a list size limit, so we specify a limit higher than the upper bound of our expectations and search for all tags within that limit without pagination.  