### PR TITLE
Update _mirror-index.sh klusterlet exclusions

### DIFF
--- a/modules/pipeline-manifest/bin/_mirror-index.sh
+++ b/modules/pipeline-manifest/bin/_mirror-index.sh
@@ -150,7 +150,7 @@ if [[ -z $SKIP_INDEX ]]; then
   export REDHAT_REGISTRY_TOKEN=$(curl --silent -u "$PIPELINE_MANIFEST_REDHAT_USER":$PIPELINE_MANIFEST_REDHAT_TOKEN "https://sso.redhat.com/auth/realms/rhcc/protocol/redhat-docker-v2/auth?service=docker-registry&client_id=curl&scope=repository:rhel:pull" | jq -r '.access_token')
 
   # Call make_index with klusterlet, but it only came into being in 2.2
-  if [[ "$PIPELINE_MANIFEST_RELEASE_VERSION" == "2.0" || "$PIPELINE_MANIFEST_RELEASE_VERSION" == "2.1" ]]; then echo No klusterlet index expected in version $PIPELINE_MANIFEST_RELEASE_VERSION;
+  if [[ "$PIPELINE_MANIFEST_RELEASE_VERSION" == "2.0" || "$PIPELINE_MANIFEST_RELEASE_VERSION" == "2.1" || "$PIPELINE_MANIFEST_RELEASE_VERSION" == "2.6" ]]; then echo No klusterlet index expected in version $PIPELINE_MANIFEST_RELEASE_VERSION;
   else
     echo Skipping klusterlet processing for the time being
     #echo klusterlet index expected in version $PIPELINE_MANIFEST_RELEASE_VERSION


### PR DESCRIPTION
Following off-boarding of klusterlet-operator-bundle from MCE 2.6.0, we need to update mirror to exclude klusterlet from the expected build mirror.