### PR TITLE
Detect GLIBC version for `oc`

### DIFF
--- a/modules/oc/Makefile
+++ b/modules/oc/Makefile
@@ -1,12 +1,12 @@
 # A simple build harness module to install the newest version of the oc cli.
 
-OC_BUILD_VERSION?=latest
+OC_BUILD_VERSION ?= latest
 OC_PLATFORM ?= $(shell echo $(BUILD_HARNESS_OS) | sed 's/darwin/mac/g')
-OC_SOURCE_URL?="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_BUILD_VERSION}/openshift-client-${OC_PLATFORM}.tar.gz"
+OC_SOURCE_URL ?= https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$(OC_BUILD_VERSION)
 
-OC_DEST_PATH?=${BUILD_HARNESS_PATH}/vendor
-OC_TAR_PATH?=${OC_DEST_PATH}/oc.tar.gz
-OC?=${OC_DEST_PATH}/oc
+OC_DEST_PATH ?= ${BUILD_HARNESS_PATH}/vendor
+OC_TAR_PATH ?= ${OC_DEST_PATH}/oc.tar.gz
+OC ?= ${OC_DEST_PATH}/oc
 OC_CLUSTER_USER ?=
 OC_CLUSTER_PASS ?=
 OC_CLUSTER_TOKEN ?=
@@ -19,14 +19,23 @@ OC_SILENT ?= true
 
 .PHONY: oc/install
 ## Install the oc cli
+#   Contains GLIBC version detection since `oc` v4.16 is compatible with GLIBC 2.32 and greater. Errors appear as:
+#   oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
 oc/install: %install:
 	@if [ ! -x $(OC) ]; then \
+		OC_BINARY="openshift-client-${OC_PLATFORM}"; \
+		if command -v ldd &>/dev/null; then \
+			OC_LIBC_VERSION="$$(ldd --version | head -1 | awk '{print $NF}')"; \
+		fi; \
+		if [ -n "$${OC_LIBC_VERSION}" ] && [  "$${OC_LIBC_VERSION%\.*}" -le "2" ] && [ "$${OC_LIBC_VERSION#*\.}" -lt "32" ]; then \
+			OC_BINARY="$${OC_BINARY}-${BUILD_HARNESS_ARCH}-rhel8"; \
+		fi; \
 		if [ ! -z "$(OC_SILENT)" ]; then \
-			curl -s -L -X GET ${OC_SOURCE_URL} -o ${OC_TAR_PATH} > /dev/null; \
+			curl -s -L -X GET ${OC_SOURCE_URL}/$${OC_BINARY}.tar.gz -o ${OC_TAR_PATH} > /dev/null; \
 			tar -xf ${OC_TAR_PATH} -C ${OC_DEST_PATH} > /dev/null; \
 			rm -f ${OC_TAR_PATH} > /dev/null; \
 		else \
-			curl -L -X GET ${OC_SOURCE_URL} -o ${OC_TAR_PATH}; \
+			curl -L -X GET ${OC_SOURCE_URL}/$${OC_BINARY}.tar.gz -o ${OC_TAR_PATH}; \
 			tar -xf ${OC_TAR_PATH} -C ${OC_DEST_PATH}; \
 			rm -f ${OC_TAR_PATH}; \
 		fi \


### PR DESCRIPTION
Need version detection for compatibility since `oc` v4.16 is only compatible with systems that have GLIBC >=v2.32. Otherwise errors like these occur:

```
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```

Related to:
- https://github.com/stolostron/image-builder/pull/139